### PR TITLE
Refactor snackbar handling and centralize config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,7 +31,8 @@ yarn-error.*
 *.pem
 
 # local env files
-.env*.local
+.env*
 
 # typescript
 *.tsbuildinfo
+store/slices/snackbarSlice.ts

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -5,6 +5,7 @@ import { store, persistor } from '../store';
 import { StatusBar } from 'expo-status-bar';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
 import { Text } from 'react-native';
+import AppWrapper from '../components/AppWrapper';
 
 export default function RootLayout() {
   return (
@@ -12,10 +13,12 @@ export default function RootLayout() {
       <PersistGate loading={<Text>Loading...</Text>} persistor={persistor}>
         <SafeAreaProvider>
           <StatusBar style="auto" />
-          <Stack screenOptions={{ headerShown: false }}>
-            <Stack.Screen name="(auth)" options={{ headerShown: false }} />
-            <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
-          </Stack>
+          <AppWrapper>
+            <Stack screenOptions={{ headerShown: false }}>
+              <Stack.Screen name="(auth)" options={{ headerShown: false }} />
+              <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
+            </Stack>
+          </AppWrapper>
         </SafeAreaProvider>
       </PersistGate>
     </Provider>

--- a/babel.config.js
+++ b/babel.config.js
@@ -4,6 +4,12 @@ module.exports = function(api) {
     presets: [
       'babel-preset-expo'
     ],
-    plugins: [],
+    plugins: [
+      ["module:react-native-dotenv", {
+        "envName": "APP_ENV",
+        "moduleName": "@env",
+        "path": ".env",
+      }]
+    ],
   };
 };

--- a/components/AppWrapper.tsx
+++ b/components/AppWrapper.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { View } from 'react-native';
+import { useSelector, useDispatch } from 'react-redux';
+import { RootState } from '../store';
+import { hideSnackbar } from '../store/slices/snackbarSlice';
+import { Snackbar } from './Snackbar';
+
+interface AppWrapperProps {
+  children: React.ReactNode;
+}
+
+const AppWrapper: React.FC<AppWrapperProps> = ({ children }) => {
+  const dispatch = useDispatch();
+  const { visible, message, type } = useSelector((state: RootState) => state.snackbar);
+
+  const handleHide = () => {
+    dispatch(hideSnackbar());
+  };
+
+  return (
+    <View style={{ flex: 1 }}>
+      {children}
+      <Snackbar
+        visible={visible}
+        message={message}
+        type={type || 'info' as any}
+        onHide={handleHide}
+      />
+    </View>
+  );
+};
+
+export default AppWrapper;

--- a/components/Snackbar.tsx
+++ b/components/Snackbar.tsx
@@ -3,7 +3,7 @@ import { View, Text, Animated, Dimensions, Platform, StyleSheet } from 'react-na
 import { SafeAreaView, useSafeAreaInsets } from 'react-native-safe-area-context';
 import { Ionicons } from '@expo/vector-icons';
 
-interface SnackBarProps {
+interface SnackbarProps {
   visible: boolean;
   message: string;
   type: 'success' | 'error';
@@ -11,7 +11,7 @@ interface SnackBarProps {
   onHide: () => void;
 }
 
-export const SnackBar: React.FC<SnackBarProps> = ({
+export const Snackbar: React.FC<SnackbarProps> = ({
   visible,
   message,
   type,

--- a/config/index.ts
+++ b/config/index.ts
@@ -1,0 +1,12 @@
+const API_URL = 'https://api-namma-kadai.vercel.app';
+
+export const config = {
+  apiUrl: API_URL,
+  auth: {
+    login: `${API_URL}/auth/login`,
+    register: `${API_URL}/auth/register`,
+    verify: `${API_URL}/auth/verify`,
+  },
+};
+
+export default config;

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
       "devDependencies": {
         "@babel/core": "^7.25.2",
         "@types/react": "~19.0.10",
+        "react-native-dotenv": "^3.4.11",
         "sass": "^1.91.0",
         "tailwindcss": "^3.3.2",
         "typescript": "~5.8.3"
@@ -7746,6 +7747,19 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/react-native-dotenv": {
+      "version": "3.4.11",
+      "resolved": "https://registry.npmjs.org/react-native-dotenv/-/react-native-dotenv-3.4.11.tgz",
+      "integrity": "sha512-6vnIE+WHABSeHCaYP6l3O1BOEhWxKH6nHAdV7n/wKn/sciZ64zPPp2NUdEUf1m7g4uuzlLbjgr+6uDt89q2DOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dotenv": "^16.4.5"
+      },
+      "peerDependencies": {
+        "@babel/runtime": "^7.20.6"
       }
     },
     "node_modules/react-native-edge-to-edge": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,8 @@
     "@react-native-async-storage/async-storage": "^2.2.0",
     "@reduxjs/toolkit": "^2.8.2",
     "expo": "~53.0.22",
+    "expo-constants": "~17.1.7",
+    "expo-linking": "~7.1.7",
     "expo-router": "~5.1.5",
     "expo-status-bar": "~2.2.3",
     "nativewind": "^4.1.23",
@@ -22,13 +24,12 @@
     "react-native-safe-area-context": "5.4.0",
     "react-native-screens": "~4.11.1",
     "react-redux": "^9.2.0",
-    "redux-persist": "^6.0.0",
-    "expo-linking": "~7.1.7",
-    "expo-constants": "~17.1.7"
+    "redux-persist": "^6.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",
     "@types/react": "~19.0.10",
+    "react-native-dotenv": "^3.4.11",
     "sass": "^1.91.0",
     "tailwindcss": "^3.3.2",
     "typescript": "~5.8.3"

--- a/store/api/authApi.ts
+++ b/store/api/authApi.ts
@@ -1,5 +1,6 @@
 import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react';
 import { RootState } from '../index';
+import config from '../../config';
 
 interface LoginRequest {
   email: string;
@@ -25,7 +26,7 @@ interface AuthResponse {
 export const authApi = createApi({
   reducerPath: 'authApi',
   baseQuery: fetchBaseQuery({
-    baseUrl: 'http://192.168.1.3:3000/auth',
+    baseUrl: `${config.apiUrl}/auth`,
     prepareHeaders: (headers, { getState }) => {
       const token = (getState() as RootState).auth.token;
       if (token) {

--- a/store/index.ts
+++ b/store/index.ts
@@ -4,6 +4,7 @@ import AsyncStorage from '@react-native-async-storage/async-storage';
 import { combineReducers } from '@reduxjs/toolkit';
 import authSlice from './slices/authSlice';
 import { authApi } from './api/authApi';
+import snackbarSlice from './slices/snackbarSlice';
 
 const persistConfig = {
   key: 'root',
@@ -13,6 +14,7 @@ const persistConfig = {
 
 const rootReducer = combineReducers({
   auth: authSlice,
+  snackbar: snackbarSlice,
   [authApi.reducerPath]: authApi.reducer,
 });
 

--- a/store/slices/authSlice.ts
+++ b/store/slices/authSlice.ts
@@ -10,48 +10,30 @@ interface AuthState {
   user: User | null;
   token: string | null;
   isAuthenticated: boolean;
-  isLoading: boolean;
-  error: string | null;
 }
 
 const initialState: AuthState = {
   user: null,
   token: null,
   isAuthenticated: false,
-  isLoading: false,
-  error: null,
 };
 
 const authSlice = createSlice({
   name: 'auth',
   initialState,
   reducers: {
-    loginStart: (state) => {
-      state.isLoading = true;
-      state.error = null;
-    },
     loginSuccess: (state, action: PayloadAction<{ user: User; token: string }>) => {
-      state.isLoading = false;
       state.user = action.payload.user;
       state.token = action.payload.token;
       state.isAuthenticated = true;
-      state.error = null;
-    },
-    loginFailure: (state, action: PayloadAction<string>) => {
-      state.isLoading = false;
-      state.error = action.payload;
     },
     logout: (state) => {
       state.user = null;
       state.token = null;
       state.isAuthenticated = false;
-      state.error = null;
-    },
-    clearError: (state) => {
-      state.error = null;
     },
   },
 });
 
-export const { loginStart, loginSuccess, loginFailure, logout, clearError } = authSlice.actions;
+export const { loginSuccess, logout } = authSlice.actions;
 export default authSlice.reducer;


### PR DESCRIPTION
Replaces local snackbar state with a global Redux slice and introduces AppWrapper for displaying snackbars across the app. Removes unused auth slice loading/error state and actions. Adds centralized API config, updates authApi to use config, and integrates react-native-dotenv for environment variables. Minor dependency and import cleanups included.